### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 Empower your AI agents (like Cline) with the ability to securely read and extract information (text, metadata, page count) from PDF files within your project context using a single, flexible tool.
 
+<a href="https://glama.ai/mcp/servers/@sylphlab/pdf-reader-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sylphlab/pdf-reader-mcp/badge" alt="PDF Reader Server MCP server" />
+</a>
+
 ## Installation
 
 ### Using npm (Recommended)


### PR DESCRIPTION
This PR adds a badge for the [PDF Reader MCP Server](https://glama.ai/mcp/servers/@sylphlab/pdf-reader-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sylphlab/pdf-reader-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sylphlab/pdf-reader-mcp/badge" alt="PDF Reader Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.